### PR TITLE
Add optional multiline support.

### DIFF
--- a/tests/test_multiline.ini
+++ b/tests/test_multiline.ini
@@ -1,0 +1,7 @@
+[Section]
+Key1: Value1
+Key2: Value Two
+Key3: this is a haiku
+    spread across separate lines
+    a single value
+Key4: Four


### PR DESCRIPTION
This patch adds optional multiline support with the `Ini.multiline` config
option.

This does not alter the default behavior, multiline support is opt-in.

- Add optional multiline config param
- Add tests to cover multiline support
- Fix some clippy lints

Fixes #26.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>