### PR TITLE
Change HashMap items from Option to Vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Old changelogs are in [CHANGELOG.md](CHANGELOG.md).
   - 😅 **BREAKING** `IniDefault` is now a non-exhaustive struct, this will make future upgrades easier and non-breaking in nature. This change might also have a few implications in updating your existing codebase, please read the [official docs](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute) for more guidance.
   - `IniDefault` is now internally used for generating defaults, reducing crate size.
   - 🚀 There is now a new optional `indexmap` feature that preserves insertion order of your loaded configurations.
+- 4.0.0 (**STABLE**)
+  - 🥵 **BREAKING** `HashMap` values are now `Vec<String>` instead of `Option<String>`. This allows the parser to now handle duplicate keys.
 
 ### 🔜 Future plans
 

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -121,7 +121,7 @@ const LINE_ENDING: &'static str = "\r\n";
 const LINE_ENDING: &'static str = "\n";
 
 impl Ini {
-    ///Creates a new `Map` of `Map<String, Map<String, Option<String>>>` type for the struct.
+    ///Creates a new `Map` of `Map<String, Map<String, Vec<String>>>` type for the struct.
     ///All values in the Map are stored in `String` type.
     ///
     ///By default, [`std::collections::HashMap`] is used for the Map object.
@@ -139,7 +139,7 @@ impl Ini {
         Ini::new_from_defaults(IniDefault::default())
     }
 
-    ///Creates a new **case-sensitive** `Map` of `Map<String, Map<String, Option<String>>>` type for the struct.
+    ///Creates a new **case-sensitive** `Map` of `Map<String, Map<String, Vec<String>>>` type for the struct.
     ///All values in the Map are stored in `String` type.
     ///## Example
     ///```rust
@@ -498,7 +498,7 @@ impl Ini {
         }
     }
 
-    ///Returns a clone of the stored value from the key stored in the defined section.
+    ///Returns a clone of the stored value(s) from the key stored in the defined section.
     ///Unlike accessing the map directly, `get()` can process your input to make case-insensitive access *if* the
     ///default constructor is used.
     ///All `get` functions will do this automatically under the hood.
@@ -511,13 +511,13 @@ impl Ini {
     ///let value = config.get("default", "defaultvalues").unwrap();
     ///assert_eq!(value, vec!["defaultvalues"]);
     ///```
-    ///Returns `Some(value)` of type `String` if value is found or else returns `None`.
+    ///Returns `Some(values)` of type `Vec<String>` if at least one value is found or else returns `None`.
     pub fn get(&self, section: &str, key: &str) -> Option<Vec<String>> {
         let (section, key) = self.autocase(section, key);
         Some(self.map.get(&section)?.get(&key)?.clone())
     }
 
-    ///Parses the stored value from the key stored in the defined section to a `bool`.
+    ///Parses the stored value(s) from the key stored in the defined section to a `bool`.
     ///For ease of use, the function converts the type case-insensitively (`true` == `True`).
     ///## Example
     ///```rust
@@ -528,7 +528,8 @@ impl Ini {
     ///let value = config.getbool("values", "bool").unwrap();
     ///assert_eq!(value, vec![true]);  // value accessible!
     ///```
-    ///Returns `Ok(Some(value))` of type `bool` if value is found or else returns `Ok(None)`.
+    ///Returns `Ok(values)` of type `Vec<bool>`.
+    ///If no value is found for the given key, it returns an empty array.
     ///If the parsing fails, it returns an `Err(string)`.
     pub fn getbool(&self, section: &str, key: &str) -> Result<Vec<bool>, String> {
         let (section, key) = self.autocase(section, key);
@@ -551,7 +552,7 @@ impl Ini {
         }
     }
 
-    ///Parses the stored value from the key stored in the defined section to a `bool`. For ease of use, the function converts the type coerces a match.
+    ///Parses the stored value(s) from the key stored in the defined section to a `bool`. For ease of use, the function converts the type coerces a match.
     ///It attempts to case-insenstively find `true`, `yes`, `t`, `y`, `1` and `on` to parse it as `True`.
     ///Similarly it attempts to case-insensitvely find `false`, `no`, `f`, `n`, `0` and `off` to parse it as `False`.
     ///## Example
@@ -563,7 +564,8 @@ impl Ini {
     ///let value = config.getboolcoerce("values", "boolcoerce").unwrap();
     ///assert_eq!(value, vec![false]);  // value accessible!
     ///```
-    ///Returns `Ok(Some(value))` of type `bool` if value is found or else returns `Ok(None)`.
+    ///Returns `Ok(values)` of type `Vec<bool>`.
+    ///If no value is found for the given key, it returns an empty array.
     ///If the parsing fails, it returns an `Err(string)`.
     pub fn getboolcoerce(&self, section: &str, key: &str) -> Result<Vec<bool>, String> {
         let (section, key) = self.autocase(section, key);
@@ -605,7 +607,7 @@ impl Ini {
         }
     }
 
-    ///Parses the stored value from the key stored in the defined section to an `i64`.
+    ///Parses the stored value(s) from the key stored in the defined section to an `i64`.
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;
@@ -615,7 +617,8 @@ impl Ini {
     ///let value = config.getint("values", "int").unwrap();
     ///assert_eq!(value, vec![-31415]);  // value accessible!
     ///```
-    ///Returns `Ok(Some(value))` of type `i64` if value is found or else returns `Ok(None)`.
+    ///Returns `Ok(values)` of type `Vec<i64>`.
+    ///If no value is found for the given key, it returns an empty array.
     ///If the parsing fails, it returns an `Err(string)`.
     pub fn getint(&self, section: &str, key: &str) -> Result<Vec<i64>, String> {
         let (section, key) = self.autocase(section, key);
@@ -638,7 +641,7 @@ impl Ini {
         }
     }
 
-    ///Parses the stored value from the key stored in the defined section to a `u64`.
+    ///Parses the stored value(s) from the key stored in the defined section to a `u64`.
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;
@@ -648,7 +651,8 @@ impl Ini {
     ///let value = config.getint("values", "Uint").unwrap();
     ///assert_eq!(value, vec![31415]);  // value accessible!
     ///```
-    ///Returns `Ok(Some(value))` of type `u64` if value is found or else returns `Ok(None)`.
+    ///Returns `Ok(values)` of type `Vec<u64>`.
+    ///If no value is found for the given key, it returns an empty array.
     ///If the parsing fails, it returns an `Err(string)`.
     pub fn getuint(&self, section: &str, key: &str) -> Result<Vec<u64>, String> {
         let (section, key) = self.autocase(section, key);
@@ -671,7 +675,7 @@ impl Ini {
         }
     }
 
-    ///Parses the stored value from the key stored in the defined section to a `f64`.
+    ///Parses the stored value(s) from the key stored in the defined section to a `f64`.
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;
@@ -681,7 +685,8 @@ impl Ini {
     ///let value = config.getfloat("values", "float").unwrap();
     ///assert_eq!(value, vec![3.1415]);  // value accessible!
     ///```
-    ///Returns `Ok(Some(value))` of type `f64` if value is found or else returns `Ok(None)`.
+    ///Returns `Ok(values)` of type `Vec<f64>`.
+    ///If no value is found for the given key, it returns an empty array.
     ///If the parsing fails, it returns an `Err(string)`.
     pub fn getfloat(&self, section: &str, key: &str) -> Result<Vec<f64>, String> {
         let (section, key) = self.autocase(section, key);
@@ -762,7 +767,8 @@ impl Ini {
         &mut self.map
     }
 
-    ///Sets an `Option<String>` in the `Map` stored in our struct. If a particular section or key does not exist, it will be automatically created.
+    ///Adds an `Option<String>` in the `Map` stored in our struct.
+    ///If a particular section or key does not exist, it will be automatically created.
     ///You can also set `None` safely.
     ///## Example
     ///```rust
@@ -777,7 +783,7 @@ impl Ini {
     ///config.set("section", "key", None);  // also valid!
     ///assert_eq!(config.get("section", "key").unwrap(), Vec::<String>::new());  // correct!
     ///```
-    ///Returns `None` if there is no existing value, else returns `Some(Option<String>)`, with the existing value being the wrapped `Option<String>`.
+    ///Returns `None` if there is no existing value, else returns `Some(Vec<String>)`, with the existing value being the wrapped `Vec<String>`.
     ///If you want to insert using a string literal, use `setstr()` instead.
     pub fn set(&mut self, section: &str, key: &str, value: Option<String>) -> Option<Vec<String>> {
         let (section, key) = self.autocase(section, key);
@@ -809,7 +815,8 @@ impl Ini {
         }
     }
 
-    ///Sets an `Option<&str>` in the `Map` stored in our struct. If a particular section or key does not exist, it will be automatically created.
+    ///Adds an `Option<&str>` in the `Map` stored in our struct.
+    ///If a particular section or key does not exist, it will be automatically created.
     ///An existing value in the map  will be overwritten. You can also set `None` safely.
     ///## Example
     ///```rust
@@ -823,7 +830,7 @@ impl Ini {
     ///config.setstr("section", "key", None);  // also valid!
     ///assert_eq!(config.get("section", "key").unwrap(), Vec::<String>::new());  // correct!
     ///```
-    ///Returns `None` if there is no existing value, else returns `Some(Option<String>)`, with the existing value being the wrapped `Option<String>`.
+    ///Returns `None` if there is no existing value, else returns `Some(Vec<String>)`, with the existing value being the wrapped `Vec<String>`.
     ///If you want to insert using a `String`, use `set()` instead.
     pub fn setstr(&mut self, section: &str, key: &str, value: Option<&str>) -> Option<Vec<String>> {
         let (section, key) = self.autocase(section, key);
@@ -883,7 +890,7 @@ impl Ini {
     ///let val = config.remove_key("anothersection", "updog").unwrap();
     ///assert_eq!(val, vec![String::from("differentdog")]);  // with the last section removed, our map is now empty!
     ///```
-    ///Returns `Some(Option<String>)` if the value exists or else, `None`.
+    ///Returns `Some(Vec<String>)` if the value exists or else, `None`.
     pub fn remove_key(&mut self, section: &str, key: &str) -> Option<Vec<String>> {
         let (section, key) = self.autocase(section, key);
         self.map.get_mut(&section)?.remove(&key)

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -371,10 +371,18 @@ impl Ini {
         // push key/value pairs in outmap to out string.
         fn unparse_key_values(out: &mut String, outmap: &Map<String, Vec<String>>) {
             for (key, val) in outmap.iter() {
-                for item in val {
+                if val.is_empty() {
                     out.push_str(&key);
-                    out.push('=');
-                    out.push_str(&item);
+                } else {
+                    let length = val.len();
+                    for (index, item) in val.iter().enumerate() {
+                        out.push_str(&key);
+                        out.push('=');
+                        out.push_str(&item);
+                        if index + 1 < length {
+                            out.push_str(LINE_ENDING);
+                        }
+                    }
                 }
                 out.push_str(LINE_ENDING);
             }
@@ -529,7 +537,7 @@ impl Ini {
                 Some(val) => {
                     let mut result = vec![];
                     for item in val {
-                        match item.parse::<bool>() {
+                        match item.to_lowercase().parse::<bool>() {
                             Ok(val) => result.push(val),
                             Err(_) => return Err(format!("{} is not a bool", item)),
                         }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -317,8 +317,8 @@ impl Ini {
     ///    Err(why) => panic!("{}", why),
     ///    Ok(inner) => inner
     ///};
-    ///let this_year = map["2000s"]["2020"].clone().unwrap();
-    ///assert_eq!(this_year, "bad"); // value accessible!
+    ///let this_year = map["2000s"]["2020"].clone();
+    ///assert_eq!(this_year, vec!["bad"]); // value accessible!
     ///```
     ///Returns `Ok(map)` with a clone of the stored `Map` if no errors are thrown or else `Err(error_string)`.
     ///Use `get_mut_map()` if you want a mutable reference.
@@ -509,7 +509,7 @@ impl Ini {
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
     ///let value = config.get("default", "defaultvalues").unwrap();
-    ///assert_eq!(value, String::from("defaultvalues"));
+    ///assert_eq!(value, vec!["defaultvalues"]);
     ///```
     ///Returns `Some(value)` of type `String` if value is found or else returns `None`.
     pub fn get(&self, section: &str, key: &str) -> Option<Vec<String>> {
@@ -525,8 +525,8 @@ impl Ini {
     ///
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
-    ///let value = config.getbool("values", "bool").unwrap().unwrap();
-    ///assert!(value);  // value accessible!
+    ///let value = config.getbool("values", "bool").unwrap();
+    ///assert_eq!(value, vec![true]);  // value accessible!
     ///```
     ///Returns `Ok(Some(value))` of type `bool` if value is found or else returns `Ok(None)`.
     ///If the parsing fails, it returns an `Err(string)`.
@@ -560,8 +560,8 @@ impl Ini {
     ///
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
-    ///let value = config.getboolcoerce("values", "boolcoerce").unwrap().unwrap();
-    ///assert!(!value);  // value accessible!
+    ///let value = config.getboolcoerce("values", "boolcoerce").unwrap();
+    ///assert_eq!(value, vec![false]);  // value accessible!
     ///```
     ///Returns `Ok(Some(value))` of type `bool` if value is found or else returns `Ok(None)`.
     ///If the parsing fails, it returns an `Err(string)`.
@@ -612,8 +612,8 @@ impl Ini {
     ///
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
-    ///let value = config.getint("values", "int").unwrap().unwrap();
-    ///assert_eq!(value, -31415);  // value accessible!
+    ///let value = config.getint("values", "int").unwrap();
+    ///assert_eq!(value, vec![-31415]);  // value accessible!
     ///```
     ///Returns `Ok(Some(value))` of type `i64` if value is found or else returns `Ok(None)`.
     ///If the parsing fails, it returns an `Err(string)`.
@@ -645,8 +645,8 @@ impl Ini {
     ///
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
-    ///let value = config.getint("values", "Uint").unwrap().unwrap();
-    ///assert_eq!(value, 31415);  // value accessible!
+    ///let value = config.getint("values", "Uint").unwrap();
+    ///assert_eq!(value, vec![31415]);  // value accessible!
     ///```
     ///Returns `Ok(Some(value))` of type `u64` if value is found or else returns `Ok(None)`.
     ///If the parsing fails, it returns an `Err(string)`.
@@ -678,8 +678,8 @@ impl Ini {
     ///
     ///let mut config = Ini::new();
     ///config.load("tests/test.ini");
-    ///let value = config.getfloat("values", "float").unwrap().unwrap();
-    ///assert_eq!(value, 3.1415);  // value accessible!
+    ///let value = config.getfloat("values", "float").unwrap();
+    ///assert_eq!(value, vec![3.1415]);  // value accessible!
     ///```
     ///Returns `Ok(Some(value))` of type `f64` if value is found or else returns `Ok(None)`.
     ///If the parsing fails, it returns an `Err(string)`.
@@ -754,8 +754,8 @@ impl Ini {
     ///  ("[topsecrets]
     ///  Valueless key"));
     /////We can then get the mutable map and insert a value like:
-    ///config.get_mut_map().get_mut("topsecrets").unwrap().insert(String::from("nuclear launch codes"), None);
-    ///assert_eq!(config.get("topsecrets", "nuclear launch codes"), None);  // inserted successfully!
+    ///config.get_mut_map().get_mut("topsecrets").unwrap().insert(String::from("nuclear launch codes"), vec![]);
+    ///assert_eq!(config.get("topsecrets", "nuclear launch codes").unwrap(), Vec::<String>::new());  // inserted successfully!
     ///```
     ///If you just need to access the map without mutating, use `get_map_ref()` or make a clone with `get_map()` instead.
     pub fn get_mut_map(&mut self) -> &mut Map<String, Map<String, Vec<String>>> {
@@ -775,7 +775,7 @@ impl Ini {
     ///let key_value = String::from("value");
     ///config.set("section", "key", Some(key_value));
     ///config.set("section", "key", None);  // also valid!
-    ///assert_eq!(config.get("section", "key"), None);  // correct!
+    ///assert_eq!(config.get("section", "key").unwrap(), Vec::<String>::new());  // correct!
     ///```
     ///Returns `None` if there is no existing value, else returns `Some(Option<String>)`, with the existing value being the wrapped `Option<String>`.
     ///If you want to insert using a string literal, use `setstr()` instead.
@@ -821,7 +821,7 @@ impl Ini {
     ///  key=notvalue"));
     ///config.setstr("section", "key", Some("value"));
     ///config.setstr("section", "key", None);  // also valid!
-    ///assert_eq!(config.get("section", "key"), None);  // correct!
+    ///assert_eq!(config.get("section", "key").unwrap(), Vec::<String>::new());  // correct!
     ///```
     ///Returns `None` if there is no existing value, else returns `Some(Option<String>)`, with the existing value being the wrapped `Option<String>`.
     ///If you want to insert using a `String`, use `set()` instead.
@@ -880,8 +880,8 @@ impl Ini {
     ///  updog=whatsupdog
     ///  [anothersection]
     ///  updog=differentdog"));
-    ///let val = config.remove_key("anothersection", "updog").unwrap().unwrap();
-    ///assert_eq!(val, String::from("differentdog"));  // with the last section removed, our map is now empty!
+    ///let val = config.remove_key("anothersection", "updog").unwrap();
+    ///assert_eq!(val, vec![String::from("differentdog")]);  // with the last section removed, our map is now empty!
     ///```
     ///Returns `Some(Option<String>)` if the value exists or else, `None`.
     pub fn remove_key(&mut self, section: &str, key: &str) -> Option<Vec<String>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ let mut config = Ini::new();
 config.read(String::from(
   "[somesection]
   someintvalue = 5"));
-let my_value = config.getint("somesection", "someintvalue").unwrap().unwrap();
-assert_eq!(my_value, 5); // value accessible!
+let my_value = config.getint("somesection", "someintvalue").unwrap();
+assert_eq!(my_value, vec![5]); // value accessible!
 
 //You can ofcourse just choose to parse the values yourself:
 let my_string = String::from("1984");
@@ -118,16 +118,16 @@ fn main() -> Result<(), Box<dyn Error>> {
   let val = config.get("TOPSECRET", "KFC").unwrap();
   // Notice how get() can access indexes case-insensitively.
 
-  assert_eq!(val, "the secret herb is orega-"); // value accessible!
+  assert_eq!(val, vec!["the secret herb is orega-"]); // value accessible!
 
   // What if you want remove KFC's secret recipe? Just use set():
   config.set("topsecret", "kfc", None);
 
-  assert_eq!(config.get("TOPSECRET", "KFC"), None); // as expected!
+  assert_eq!(config.get("TOPSECRET", "KFC").unwrap(), Vec::<String>::new()); // as expected!
 
   // What if you want to get an unsigned integer?
-  let my_number = config.getuint("values", "Uint")?.unwrap();
-  assert_eq!(my_number, 31415); // and we got it!
+  let my_number = config.getuint("values", "Uint").unwrap();
+  assert_eq!(my_number, vec![31415]); // and we got it!
   // The Ini struct provides more getters for primitive datatypes.
 
   // You can also access it like a normal hashmap:

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,74 +30,78 @@ fn non_cs() -> Result<(), Box<dyn Error>> {
     config.set("DEFAULT", "defaultvalues", Some("notdefault".to_owned()));
     assert_eq!(
         config.get("DEFAULT", "defaultvalues").unwrap(),
-        "notdefault"
+        vec!["defaultvalues", "notdefault"]
     );
     config.setstr("DEFAULT", "defaultvalues", Some("defaultvalues"));
     assert_eq!(
         config.get("DEFAULT", "defaultvalues").unwrap(),
-        "defaultvalues"
+        vec!["defaultvalues", "notdefault", "defaultvalues"]
     );
     config.setstr("DEFAULT", "defaultvalues", None);
+    config.setstr("DEFAULT", "defaultvalues", Some("defaultvalues"));
     config.write("output.ini")?;
     let map2 = config.clone().load("output.ini")?;
     assert_eq!(map2, *config.get_map_ref());
     let map3 = config.clone().read(config.writes())?;
     assert_eq!(map2, map3);
     assert_eq!(config.sections().len(), 4);
-    assert_eq!(config.get("DEFAULT", "defaultvalues"), None);
+    assert_eq!(
+        config.get("DEFAULT", "defaultvalues").unwrap(),
+        vec!["defaultvalues"]
+    );
     assert_eq!(
         config.get("topsecret", "KFC").unwrap(),
-        "the secret herb is orega-"
+        vec!["the secret herb is orega-"]
     );
-    assert_eq!(config.get("topsecret", "Empty string").unwrap(), "");
-    assert_eq!(config.get("topsecret", "None string"), None);
-    assert_eq!(config.get("spacing", "indented").unwrap(), "indented");
+    assert_eq!(config.get("topsecret", "Empty string").unwrap(), vec![""]);
+    assert_eq!(
+        config.get("topsecret", "None string").unwrap(),
+        Vec::<String>::new()
+    );
+    assert_eq!(config.get("spacing", "indented").unwrap(), vec!["indented"]);
     assert_eq!(
         config.get("spacing", "not indented").unwrap(),
-        "not indented"
+        vec!["not indented"]
     );
     assert_eq!(
         config.get("topsecret", "colon").unwrap(),
-        "value after colon"
+        vec!["value after colon"]
     );
-    assert_eq!(config.getbool("values", "Bool")?.unwrap(), true);
+    assert_eq!(config.getbool("values", "Bool").unwrap(), vec![true]);
     assert_eq!(
-        config.getboolcoerce("values", "Boolcoerce")?.unwrap(),
-        false
+        config.getboolcoerce("values", "Boolcoerce").unwrap(),
+        vec![false]
     );
-    assert_eq!(config.getint("values", "Int")?.unwrap(), -31415);
-    assert_eq!(config.getuint("values", "Uint")?.unwrap(), 31415);
-    assert_eq!(config.getfloat("values", "Float")?.unwrap(), 3.1415);
-    assert_eq!(config.getfloat("topsecret", "None string"), Ok(None));
+    assert_eq!(config.getint("values", "Int").unwrap(), vec![-31415]);
+    assert_eq!(config.getuint("values", "Uint").unwrap(), vec![31415]);
+    assert_eq!(config.getfloat("values", "Float").unwrap(), vec![3.1415]);
+    assert_eq!(config.getfloat("topsecret", "None string").unwrap(), vec![]);
     assert_eq!(
-        map["default"]["defaultvalues"].clone().unwrap(),
-        "defaultvalues"
+        map["default"]["defaultvalues"].clone(),
+        vec!["defaultvalues"]
     );
     assert_eq!(
-        map["topsecret"]["kfc"].clone().unwrap(),
-        "the secret herb is orega-"
+        map["topsecret"]["kfc"].clone(),
+        vec!["the secret herb is orega-"]
     );
-    assert_eq!(map["topsecret"]["empty string"].clone().unwrap(), "");
-    assert_eq!(map["topsecret"]["none string"], None);
-    assert_eq!(map["spacing"]["indented"].clone().unwrap(), "indented");
-    assert_eq!(
-        map["spacing"]["not indented"].clone().unwrap(),
-        "not indented"
-    );
+    assert_eq!(map["topsecret"]["empty string"].clone(), vec![""]);
+    assert_eq!(map["topsecret"]["none string"].len(), 0);
+    assert_eq!(map["spacing"]["indented"].clone(), vec!["indented"]);
+    assert_eq!(map["spacing"]["not indented"].clone(), vec!["not indented"]);
     let mut config2 = config.clone();
     let val = config2.remove_key("default", "defaultvalues");
-    assert_eq!(val, Some(None));
+    assert_eq!(val.unwrap(), vec!["defaultvalues"]);
     assert_eq!(config2.get("default", "defaultvalues"), None);
     config2.remove_section("default");
     assert_eq!(config2.get("default", "nope"), None);
     let mut_map = config.get_mut_map();
     mut_map.get_mut("topsecret").unwrap().insert(
         String::from("none string"),
-        Some(String::from("None string")),
+        vec![String::from("None string")],
     );
     assert_eq!(
-        mut_map["topsecret"]["none string"].clone().unwrap(),
-        "None string"
+        mut_map["topsecret"]["none string"].clone(),
+        vec!["None string"]
     );
     mut_map.clear();
     config2.clear();
@@ -134,74 +138,79 @@ fn cs() -> Result<(), Box<dyn Error>> {
     config.set("default", "defaultvalues", Some("notdefault".to_owned()));
     assert_eq!(
         config.get("default", "defaultvalues").unwrap(),
-        "notdefault"
+        vec!["defaultvalues", "notdefault"]
     );
     config.setstr("default", "defaultvalues", Some("defaultvalues"));
     assert_eq!(
         config.get("default", "defaultvalues").unwrap(),
-        "defaultvalues"
+        vec!["defaultvalues", "notdefault", "defaultvalues"]
     );
     config.setstr("default", "defaultvalues", None);
+    config.setstr("default", "defaultvalues", Some("defaultvalues"));
+
     config.write("output2.ini")?;
     let map2 = config.clone().load("output2.ini")?;
     assert_eq!(map2, *config.get_map_ref());
     let map3 = config.clone().read(config.writes())?;
     assert_eq!(map2, map3);
     assert_eq!(config.sections().len(), 4);
-    assert_eq!(config.get("default", "defaultvalues"), None);
+    assert_eq!(
+        config.get("default", "defaultvalues").unwrap(),
+        vec!["defaultvalues"]
+    );
     assert_eq!(
         config.get("topsecret", "KFC").unwrap(),
-        "the secret herb is orega-"
+        vec!["the secret herb is orega-"]
     );
-    assert_eq!(config.get("topsecret", "Empty string").unwrap(), "");
-    assert_eq!(config.get("topsecret", "None string"), None);
-    assert_eq!(config.get("spacing", "indented").unwrap(), "indented");
+    assert_eq!(config.get("topsecret", "Empty string").unwrap(), vec![""]);
+    assert_eq!(
+        config.get("topsecret", "None string").unwrap(),
+        Vec::<String>::new()
+    );
+    assert_eq!(config.get("spacing", "indented").unwrap(), vec!["indented"]);
     assert_eq!(
         config.get("spacing", "not indented").unwrap(),
-        "not indented"
+        vec!["not indented"]
     );
     assert_eq!(
         config.get("topsecret", "colon").unwrap(),
-        "value after colon"
+        vec!["value after colon"]
     );
-    assert_eq!(config.getbool("values", "Bool")?.unwrap(), true);
+    assert_eq!(config.getbool("values", "Bool").unwrap(), vec![true]);
     assert_eq!(
-        config.getboolcoerce("values", "Boolcoerce")?.unwrap(),
-        false
+        config.getboolcoerce("values", "Boolcoerce").unwrap(),
+        vec![false]
     );
-    assert_eq!(config.getint("values", "Int")?.unwrap(), -31415);
-    assert_eq!(config.getuint("values", "Uint")?.unwrap(), 31415);
-    assert_eq!(config.getfloat("values", "Float")?.unwrap(), 3.1415);
-    assert_eq!(config.getfloat("topsecret", "None string"), Ok(None));
+    assert_eq!(config.getint("values", "Int").unwrap(), vec![-31415]);
+    assert_eq!(config.getuint("values", "Uint").unwrap(), vec![31415]);
+    assert_eq!(config.getfloat("values", "Float").unwrap(), vec![3.1415]);
+    assert_eq!(config.getfloat("topsecret", "None string").unwrap(), vec![]);
     assert_eq!(
-        map["default"]["defaultvalues"].clone().unwrap(),
-        "defaultvalues"
+        map["default"]["defaultvalues"].clone(),
+        vec!["defaultvalues"]
     );
     assert_eq!(
-        map["topsecret"]["KFC"].clone().unwrap(),
-        "the secret herb is orega-"
+        map["topsecret"]["KFC"].clone(),
+        vec!["the secret herb is orega-"]
     );
-    assert_eq!(map["topsecret"]["Empty string"].clone().unwrap(), "");
-    assert_eq!(map["topsecret"]["None string"], None);
-    assert_eq!(map["spacing"]["indented"].clone().unwrap(), "indented");
-    assert_eq!(
-        map["spacing"]["not indented"].clone().unwrap(),
-        "not indented"
-    );
+    assert_eq!(map["topsecret"]["Empty string"].clone(), vec![""]);
+    assert_eq!(map["topsecret"]["None string"].len(), 0);
+    assert_eq!(map["spacing"]["indented"].clone(), vec!["indented"]);
+    assert_eq!(map["spacing"]["not indented"].clone(), vec!["not indented"]);
     let mut config2 = config.clone();
     let val = config2.remove_key("default", "defaultvalues");
-    assert_eq!(val, Some(None));
+    assert_eq!(val.unwrap(), ["defaultvalues"]);
     assert_eq!(config2.get("default", "defaultvalues"), None);
     config2.remove_section("default");
     assert_eq!(config2.get("default", "nope"), None);
     let mut_map = config.get_mut_map();
     mut_map.get_mut("topsecret").unwrap().insert(
         String::from("none string"),
-        Some(String::from("None string")),
+        vec![String::from("None string")],
     );
     assert_eq!(
-        mut_map["topsecret"]["none string"].clone().unwrap(),
-        "None string"
+        mut_map["topsecret"]["none string"].clone(),
+        vec!["None string"]
     );
     mut_map.clear();
     config2.clear();


### PR DESCRIPTION
Hello, while using your library to parse a [systemd-networkd](https://wiki.archlinux.org/title/systemd-networkd) file, we noticed that the `DNS=` line could be specified more than once, so we adapted your library to use `Vec<String>` instead of `Option<String>`.
Obviously this is a breaking update, but I personally think that the library would be more flexible with this change.