### PR TITLE
Implement load and write as async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 output.ini
 output2.ini
 test2.ini
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ output.ini
 output2.ini
 test2.ini
 .vscode
+output_async.ini
+output_sync.ini

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configparser"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["QEDK <qedk.en@gmail.com>"]
 edition = "2021"
 description = "A simple configuration parsing utility with no dependencies that allows you to parse INI and ini-style syntax. You can use this to write Rust programs which can be customized by end users easily."
@@ -19,4 +19,5 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-std = { version = "1.12.0", optional = true }
 indexmap = { version = "1.7", optional = true }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -5,6 +5,13 @@ use indexmap::IndexMap as Map;
 #[cfg(not(feature = "indexmap"))]
 use std::collections::HashMap as Map;
 
+#[cfg(feature = "async-std")]
+use async_std::{
+    fs as async_fs,
+    fs::File as AsyncFile,
+    io::ReadExt,
+};
+
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::fs;
@@ -847,5 +854,48 @@ impl Ini {
     pub fn remove_key(&mut self, section: &str, key: &str) -> Option<Option<String>> {
         let (section, key) = self.autocase(section, key);
         self.map.get_mut(&section)?.remove(&key)
+    }
+}
+
+#[cfg(feature = "async-std")]
+impl Ini {
+    ///Loads a file asynchronously from a defined path, parses it and puts the hashmap into our struct.
+    ///At one time, it only stores one configuration, so each call to `load()` or `read()` will clear the existing `Map`, if present.
+    /// 
+    ///Usage is similar to `load`, but `.await` must be called after along with the usual async rules.
+    /// 
+    ///Returns `Ok(map)` with a clone of the stored `Map` if no errors are thrown or else `Err(error_string)`.
+    ///Use `get_mut_map()` if you want a mutable reference.
+    pub async fn load_async<T: AsRef<Path>>(
+        &mut self,
+        path: T,
+    ) -> Result<Map<String, Map<String, Option<String>>>, String> {
+        let path = path.as_ref();
+        let display = path.display();
+
+        let mut file = match AsyncFile::open(&path).await {
+            Err(why) => return Err(format!("couldn't open {}: {}", display, why)),
+            Ok(file) => file,
+        };
+
+        let mut s = String::new();
+        self.map = match file.read_to_string(&mut s).await {
+            Err(why) => return Err(format!("couldn't read {}: {}", display, why)),
+            Ok(_) => match self.parse(s) {
+                Err(why) => return Err(why),
+                Ok(map) => map,
+            },
+        };
+        Ok(self.map.clone())
+    }
+
+    ///Writes the current configuation to the specified path asynchronously. If a file is not present, it is automatically created for you, if a file already
+    ///exists, it is truncated and the configuration is written to it.
+    /// 
+    ///Usage is the same as `write`, but `.await` must be called after along with the usual async rules.
+    /// 
+    ///Returns a `std::io::Result<()>` type dependent on whether the write was successful or not.
+    pub async fn write_async<T: AsRef<Path>>(&self, path: T) -> std::io::Result<()> {
+        async_fs::write(path.as_ref(), self.unparse()).await
     }
 }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -6,11 +6,7 @@ use indexmap::IndexMap as Map;
 use std::collections::HashMap as Map;
 
 #[cfg(feature = "async-std")]
-use async_std::{
-    fs as async_fs,
-    fs::File as AsyncFile,
-    io::ReadExt,
-};
+use async_std::{fs as async_fs, fs::File as AsyncFile, io::ReadExt};
 
 use std::collections::HashMap;
 use std::convert::AsRef;
@@ -861,9 +857,9 @@ impl Ini {
 impl Ini {
     ///Loads a file asynchronously from a defined path, parses it and puts the hashmap into our struct.
     ///At one time, it only stores one configuration, so each call to `load()` or `read()` will clear the existing `Map`, if present.
-    /// 
+    ///
     ///Usage is similar to `load`, but `.await` must be called after along with the usual async rules.
-    /// 
+    ///
     ///Returns `Ok(map)` with a clone of the stored `Map` if no errors are thrown or else `Err(error_string)`.
     ///Use `get_mut_map()` if you want a mutable reference.
     pub async fn load_async<T: AsRef<Path>>(
@@ -891,9 +887,9 @@ impl Ini {
 
     ///Writes the current configuation to the specified path asynchronously. If a file is not present, it is automatically created for you, if a file already
     ///exists, it is truncated and the configuration is written to it.
-    /// 
+    ///
     ///Usage is the same as `write`, but `.await` must be called after along with the usual async rules.
-    /// 
+    ///
     ///Returns a `std::io::Result<()>` type dependent on whether the write was successful or not.
     pub async fn write_async<T: AsRef<Path>>(&self, path: T) -> std::io::Result<()> {
         async_fs::write(path.as_ref(), self.unparse()).await

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -868,10 +868,25 @@ impl Ini {
         &mut self,
         path: T,
     ) -> Result<Map<String, Map<String, Option<String>>>, String> {
-        let s = async_fs::read_to_string(&path)
-            .await
-            .map_err(|why| format!("couldn't read {}: {}", path.as_ref().display(), why))?;
-        self.map = self.parse(s)?;
+        self.map = match self.parse(match async_fs::read_to_string(&path).await {
+            Err(why) => {
+                return Err(format!(
+                    "couldn't read {}: {}",
+                    &path.as_ref().display(),
+                    why
+                ))
+            }
+            Ok(s) => s,
+        }) {
+            Err(why) => {
+                return Err(format!(
+                    "couldn't read {}: {}",
+                    &path.as_ref().display(),
+                    why
+                ))
+            }
+            Ok(map) => map,
+        };
         Ok(self.map.clone())
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -235,27 +235,7 @@ Float=3.1415
 
 #[test]
 #[cfg(feature = "async-std")]
-fn async_read() -> Result<(), Box<dyn Error>> {
-    let mut config_sync = Ini::new();
-    config_sync.load("tests/test.ini")?;
-
-    let config_async = async_std::task::block_on::<_, Result<_, String>>(async {
-        let mut config_async = Ini::new();
-        config_async.load_async("tests/test.ini").await?;
-        Ok(config_async)
-    })?;
-
-    assert_eq!(config_sync, config_async);
-
-    Ok(())
-}
-
-#[cfg(feature = "async-std")]
-use std::fs;
-
-#[test]
-#[cfg(feature = "async-std")]
-fn async_write() -> Result<(), Box<dyn Error>> {
+fn async_load_write() -> Result<(), Box<dyn Error>> {
     const OUT_FILE_CONTENTS: &str = "defaultvalues=defaultvalues
     [topsecret]
     KFC = the secret herb is orega-
@@ -288,8 +268,14 @@ fn async_write() -> Result<(), Box<dyn Error>> {
         Ok(())
     })?;
 
-    let sync_content = fs::read_to_string("output_sync.ini")?;
-    let async_content = fs::read_to_string("output_async.ini")?;
+    let mut sync_content = Ini::new();
+    sync_content.load("output_sync.ini")?;
+
+    let async_content = async_std::task::block_on::<_, Result<_, String>>(async {
+        let mut async_content = Ini::new();
+        async_content.load_async("output_async.ini").await?;
+        Ok(async_content)
+    })?;
 
     assert_eq!(sync_content, async_content);
 


### PR DESCRIPTION
This adds a new feature (+ dependency) `async-std`.

When the feature is enabled, two additional functions are implemented on top of everything else: `load_async` and `write_async`.

This is primarily useful for me, in my project, as I'm loading many cfg files, and being able to run other code while a file is being read from the disk is very useful.

So here I am with this code and PR. It was straightforward and didn't take long, but this is the most popular parsing crate for this file type I could find.