### PR TITLE
Implement parsing multiline configs from #28

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -498,7 +498,7 @@ impl Ini {
                     Some(x) => x,
                     None => {
                         return Err(format!(
-                            "line {} started with identation but there is no current entry",
+                            "line {}: Started with indentation but there is no current entry",
                             num,
                         ))
                     }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -85,7 +85,7 @@ pub struct IniDefault {
     ///assert_eq!(default.case_sensitive, false);
     ///```
     pub case_sensitive: bool,
-    ///Denotes if the `Ini` object is parses multiline strings.
+    ///Denotes if the `Ini` object parses multiline strings.
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;

--- a/tests/test_multiline.ini
+++ b/tests/test_multiline.ini
@@ -1,0 +1,7 @@
+[Section]
+Key1: Value1
+Key2: Value Two
+Key3: this is a haiku
+    spread across separate lines
+    a single value
+Key4: Four


### PR DESCRIPTION
Re-implements PR #28 with requested changes and moving tests to the `tests.rs` file.

Will also close #26 .