### PR TITLE
feat: added load_more to accumulate multiple configs

### DIFF
--- a/tests/test_more.ini
+++ b/tests/test_more.ini
@@ -1,0 +1,8 @@
+defaultvalues=overwritten
+
+[topsecret]
+KFC = redacted
+
+[values]
+Bool = False
+


### PR DESCRIPTION
Fixes #41 

- [x] Change is **_NON-BREAKING_**
- [x] Adds `load_and_append()`
    - [x] Full test coverage
    - [x] Coherent docs
- [x] Adds `load_and_append_async()`
    - [x] Full test coverage
    - [x] Coherent docs
- [x] Adds `read_and_append()`
    - [x] Full test coverage
    - [x] Coherent docs