### PR TITLE
Preserve blank lines within multiline values

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -534,7 +534,7 @@ fn multiline_on() -> Result<(), Box<dyn Error>> {
     assert_eq!(config.get("Section", "Key2").unwrap(), "Value Two");
     assert_eq!(
         config.get("Section", "Key3").unwrap(),
-        "this is a haiku\nspread across separate lines\na single value"
+        "this is a haiku\nspread across separate lines\n\na single value"
     );
     assert_eq!(config.get("Section", "Key4").unwrap(), "Four");
 
@@ -545,6 +545,7 @@ Key1=Value1
 Key2=Value Two
 Key3=this is a haiku
     spread across separate lines
+
     a single value
 Key4=Four
 "

--- a/tests/test_multiline.ini
+++ b/tests/test_multiline.ini
@@ -3,5 +3,7 @@ Key1: Value1
 Key2: Value Two
 Key3: this is a haiku
     spread across separate lines
+    # This is a comment
+
     a single value
 Key4: Four


### PR DESCRIPTION
## Summary

Given an INI file like:

```
[externally-managed]
Error=To install Python packages system-wide, try brew install
 xyz, where xyz is the package you are trying to
 install.

 If you wish to install a non-brew-packaged Python package,
 create a virtual environment using python3 -m venv path/to/venv.
 Then use path/to/venv/bin/python and path/to/venv/bin/pip.

 If you wish to install a non-brew packaged Python application,
 it may be easiest to use pipx install xyz, which will manage a
 virtual environment for you. Make sure you have pipx installed.
```

Python's `configparser` preserves the empty lines within the multiline value, while the `configparser` crate drops them.

This PR adds support for preserving those blank lines based on following the Python `configparser` rules, so...

- Empty lines _after_ the value are dropped (even if there's another value that follows it).
- Empty lines that consist of _just_ comments are dropped (even if they're indented).
