### PR TITLE
Ensure empty sections are parsed but empty

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -761,6 +761,8 @@ impl Ini {
                 (Some(0), Some(end)) => {
                     section = caser(trimmed[1..end].trim());
 
+                    map.entry(section.clone()).or_default();
+
                     continue;
                 }
                 (Some(0), None) => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -232,6 +232,25 @@ fn cs() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn ensure_empty_sections_exist() -> Result<(), Box<dyn Error>> {
+    const FILE_CONTENTS: &str = "
+[basic_section]
+basic_option=basic_value
+[empty_section]
+";
+
+    let mut config = Ini::new();
+    config.read(FILE_CONTENTS.to_owned())?;
+
+    assert_eq!(
+        config.sections(),
+        vec![String::from("basic_section"), String::from("empty_section")]
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "indexmap")]
 fn sort_on_write() -> Result<(), Box<dyn Error>> {
     let mut config = Ini::new_cs();


### PR DESCRIPTION
Hello! We recently started using this library and noticed that empty sections don't show up via the `.sections()` method. This fixes that by inserting an empty HashMap when the section name is parsed, rather than waiting for the first value to be added.

I didn't add an option for it, but it seems like if you consider this a breaking change, it would be fairly easy to put behind an additional config value in the IniDefault type.

Fixes #37 

I can also open issues for them, but what would your thoughts be on "has_section" and "create_section" methods? I notice neither of those prefixes is used, so another name might work better, I just wasn't sure what. "insert_section" would be an option, but that's sort of implied to take a `Map`, which wasn't what I was going for... though I suppose it would work.