### PR TITLE
Make inline comment separators separate from comment separators

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -251,6 +251,81 @@ basic_option=basic_value
 }
 
 #[test]
+fn inline_comment_symbols() -> Result<(), Box<dyn Error>> {
+    const FILE_CONTENTS: &str = "
+[basic_section]
+; basic comment
+ ; comment with space
+! extra_comment=
+basic_option=value
+basic_with_comment=value ; Simple comment
+basic_with_extra_inline=value ! comment
+empty_option=
+";
+
+    let mut config = Ini::new();
+    config.read(FILE_CONTENTS.to_owned())?;
+
+    assert_eq!(
+        config.get("basic_section", "basic_option"),
+        Some(String::from("value"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_comment"),
+        Some(String::from("value"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_extra_inline"),
+        Some(String::from("value ! comment"))
+    );
+    assert_eq!(
+        config.get("basic_section", "! extra_comment"),
+        Some(String::from(""))
+    );
+
+    assert_eq!(
+        config.get("basic_section", "empty_option"),
+        Some(String::from(""))
+    );
+
+    config.set_inline_comment_symbols(Some(&['!']));
+
+    config.read(FILE_CONTENTS.to_owned())?;
+
+    assert_eq!(
+        config.get("basic_section", "basic_option"),
+        Some(String::from("value"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_comment"),
+        Some(String::from("value ; Simple comment"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_extra_inline"),
+        Some(String::from("value"))
+    );
+
+    config.set_inline_comment_symbols(Some(&[]));
+
+    config.read(FILE_CONTENTS.to_owned())?;
+
+    assert_eq!(
+        config.get("basic_section", "basic_option"),
+        Some(String::from("value"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_comment"),
+        Some(String::from("value ; Simple comment"))
+    );
+    assert_eq!(
+        config.get("basic_section", "basic_with_extra_inline"),
+        Some(String::from("value ! comment"))
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "indexmap")]
 fn sort_on_write() -> Result<(), Box<dyn Error>> {
     let mut config = Ini::new_cs();


### PR DESCRIPTION
This adds an option to set inline comment separators separate from the comment separators, similar to the inline_comment_prefixes in the [Customizing Parser Behavior section](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour) of the Python library docs.

Notes:
* An `Option<Vec<char>>` was used to keep the current behavior as the default - updating the comment separators will carry over to the inline comment separators if inline is not set. This allows it to be made as a backwards compatible change.
* The parsing logic was tweaked slightly slightly to make it easier to understand and allow for parsing inline comments separate from full line comments.