### PR TITLE
Update README.md to include example of overriding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ You can activate it by adding it as a feature like this:
 configparser = { version = "3.2.0", features = ["tokio"] }
 ```
 
+## Override Defaults 
+
+You can change the default configuration options like this. See the API for more verbose documentation.
+
+```
+let mut default = IniDefault::default();
+default.multiline = true;
+let mut config = Ini::new_from_defaults(default);
+```
+
 ## 📜 License
 
 Licensed under either of


### PR DESCRIPTION
This was a feature we were looking for, and were able to use by looking at `src/ini.rs`. Having a quick example on the page would have helped us