### PR TITLE
Add cascading defaults as an IniDefault option

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -36,7 +36,7 @@ pub struct Ini {
     case_sensitive: bool,
     multiline: bool,
     enable_inline_comments: bool,
-    cascade_defaults: bool
+    cascade_defaults: bool,
 }
 
 #[cfg(all(feature = "serde", not(feature = "indexmap")))]
@@ -181,7 +181,7 @@ pub struct IniDefault {
     ///## Example
     ///```rust
     ///use configparser::ini::Ini;
-    /// 
+    ///
     ///let mut config = Ini::new();
     ///let default = config.defaults();
     ///assert_eq!(default.cascade_defaults, false);
@@ -218,7 +218,7 @@ impl Default for IniDefault {
             .collect(),
             case_sensitive: false,
             enable_inline_comments: true, // retain compatibility with previous versions
-            cascade_defaults: false,  // retain backwards compatibility
+            cascade_defaults: false,      // retain backwards compatibility
         }
     }
 }
@@ -1061,7 +1061,7 @@ impl Ini {
                     return self.getbool(&self.default_section, &key);
                 }
                 Ok(None)
-            },
+            }
         }
     }
 
@@ -1114,21 +1114,21 @@ impl Ini {
                             return self.getboolcoerce(&self.default_section, &key);
                         }
                         Ok(None)
-                    },
+                    }
                 },
                 None => {
                     if self.cascade_defaults && section != self.default_section {
                         return self.getboolcoerce(&self.default_section, &key);
                     }
                     Ok(None)
-                },
+                }
             },
             None => {
                 if self.cascade_defaults && section != self.default_section {
                     return self.getboolcoerce(&self.default_section, &key);
                 }
                 Ok(None)
-            },
+            }
         }
     }
 
@@ -1158,21 +1158,21 @@ impl Ini {
                             return self.getint(&self.default_section, &key);
                         }
                         Ok(None)
-                    },
+                    }
                 },
                 None => {
                     if self.cascade_defaults && section != self.default_section {
                         return self.getint(&self.default_section, &key);
                     }
                     Ok(None)
-                },
+                }
             },
             None => {
                 if self.cascade_defaults && section != self.default_section {
                     return self.getint(&self.default_section, &key);
                 }
                 Ok(None)
-            },
+            }
         }
     }
 
@@ -1202,21 +1202,21 @@ impl Ini {
                             return self.getuint(&self.default_section, &key);
                         }
                         Ok(None)
-                    },
+                    }
                 },
                 None => {
                     if self.cascade_defaults && section != self.default_section {
                         return self.getuint(&self.default_section, &key);
                     }
                     Ok(None)
-                },
+                }
             },
             None => {
                 if self.cascade_defaults && section != self.default_section {
                     return self.getuint(&self.default_section, &key);
                 }
                 Ok(None)
-            },
+            }
         }
     }
 
@@ -1246,21 +1246,21 @@ impl Ini {
                             return self.getfloat(&self.default_section, &key);
                         }
                         Ok(None)
-                    },
+                    }
                 },
                 None => {
                     if self.cascade_defaults && section != self.default_section {
                         return self.getfloat(&self.default_section, &key);
                     }
                     Ok(None)
-                },
+                }
             },
             None => {
                 if self.cascade_defaults && section != self.default_section {
                     return self.getfloat(&self.default_section, &key);
                 }
                 Ok(None)
-            },
+            }
         }
     }
 

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -506,7 +506,6 @@ impl Ini {
     ///let val = config.get("mysection", "fallback_key");  // Will fall back to the [DEFAULT] section for "key"
     ///assert_eq!(val, Some(String::from("fallback value")));
     ///```
-    ///Returns nothing.   /// 
     pub fn set_cascade_defaults(&mut self, cascade_defaults: bool) {
         self.cascade_defaults = cascade_defaults;
     }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -36,6 +36,7 @@ pub struct Ini {
     case_sensitive: bool,
     multiline: bool,
     enable_inline_comments: bool,
+    cascade_defaults: bool
 }
 
 #[cfg(all(feature = "serde", not(feature = "indexmap")))]
@@ -174,6 +175,18 @@ pub struct IniDefault {
     ///assert_eq!(default.enable_inline_comments, true);
     ///```
     pub enable_inline_comments: bool,
+    ///Cascade defaults automatically.  If a key is not defined in a get*()
+    ///call, but exists in the [DEFAULT] section, the value in the [DEFAULT]
+    ///section will be returned.
+    ///## Example
+    ///```rust
+    ///use configparser::ini::Ini;
+    /// 
+    ///let mut config = Ini::new();
+    ///let default = config.defaults();
+    ///assert_eq!(default.cascade_defaults, false);
+    ///```
+    pub cascade_defaults: bool,
 }
 
 impl Default for IniDefault {
@@ -205,6 +218,7 @@ impl Default for IniDefault {
             .collect(),
             case_sensitive: false,
             enable_inline_comments: true, // retain compatibility with previous versions
+            cascade_defaults: false,  // retain backwards compatibility
         }
     }
 }
@@ -365,6 +379,7 @@ impl Ini {
             case_sensitive: defaults.case_sensitive,
             multiline: defaults.multiline,
             enable_inline_comments: defaults.enable_inline_comments,
+            cascade_defaults: defaults.cascade_defaults,
         }
     }
 
@@ -387,6 +402,7 @@ impl Ini {
             case_sensitive: self.case_sensitive,
             multiline: self.multiline,
             enable_inline_comments: self.enable_inline_comments,
+            cascade_defaults: self.cascade_defaults,
         }
     }
 
@@ -473,6 +489,26 @@ impl Ini {
     ///Returns nothing.
     pub fn set_multiline(&mut self, multiline: bool) {
         self.multiline = multiline;
+    }
+
+    ///Sets the behavior around the cascading of defaults.  If this is set
+    ///to `true`, a get*() call for a section without a matching key value will
+    ///attempt to get that key value from the [DEFAULT] section if it exists
+    ///there.
+    ///## Example
+    ///```rust
+    ///use configparser::ini::Ini;
+    ///
+    ///let mut config = Ini::new();
+    ///config.set_cascade_defaults(true);
+    ///let map = config.load("tests/test_cascade_defaults.ini").unwrap();
+    ///
+    ///let val = config.get("mysection", "fallback_key");  // Will fall back to the [DEFAULT] section for "key"
+    ///assert_eq!(val, Some(String::from("fallback value")));
+    ///```
+    ///Returns nothing.   /// 
+    pub fn set_cascade_defaults(&mut self, cascade_defaults: bool) {
+        self.cascade_defaults = cascade_defaults;
     }
 
     ///Gets all the sections of the currently-stored `Map` in a vector.
@@ -970,7 +1006,19 @@ impl Ini {
     ///Returns `Some(value)` of type `String` if value is found or else returns `None`.
     pub fn get(&self, section: &str, key: &str) -> Option<String> {
         let (section, key) = self.autocase(section, key);
-        self.map.get(&section)?.get(&key)?.clone()
+        let val = match self.map.get(&section) {
+            Some(secmap) => match secmap.get(&key) {
+                Some(val) => val.clone(),
+                None => None,
+            },
+            None => None,
+        };
+
+        if val.is_none() && self.cascade_defaults {
+            return self.map.get(&self.default_section)?.get(&key)?.clone();
+        }
+
+        val
     }
 
     ///Parses the stored value from the key stored in the defined section to a `bool`.
@@ -995,11 +1043,26 @@ impl Ini {
                         Err(why) => Err(why.to_string()),
                         Ok(boolean) => Ok(Some(boolean)),
                     },
-                    None => Ok(None),
+                    None => {
+                        if self.cascade_defaults && section != self.default_section {
+                            return self.getbool(&self.default_section, &key);
+                        }
+                        Ok(None)
+                    }
                 },
-                None => Ok(None),
+                None => {
+                    if self.cascade_defaults && section != self.default_section {
+                        return self.getbool(&self.default_section, &key);
+                    }
+                    Ok(None)
+                }
             },
-            None => Ok(None),
+            None => {
+                if self.cascade_defaults && section != self.default_section {
+                    return self.getbool(&self.default_section, &key);
+                }
+                Ok(None)
+            },
         }
     }
 
@@ -1047,11 +1110,26 @@ impl Ini {
                             ))
                         }
                     }
-                    None => Ok(None),
+                    None => {
+                        if self.cascade_defaults && section != self.default_section {
+                            return self.getboolcoerce(&self.default_section, &key);
+                        }
+                        Ok(None)
+                    },
                 },
-                None => Ok(None),
+                None => {
+                    if self.cascade_defaults && section != self.default_section {
+                        return self.getboolcoerce(&self.default_section, &key);
+                    }
+                    Ok(None)
+                },
             },
-            None => Ok(None),
+            None => {
+                if self.cascade_defaults && section != self.default_section {
+                    return self.getboolcoerce(&self.default_section, &key);
+                }
+                Ok(None)
+            },
         }
     }
 
@@ -1076,11 +1154,26 @@ impl Ini {
                         Err(why) => Err(why.to_string()),
                         Ok(int) => Ok(Some(int)),
                     },
-                    None => Ok(None),
+                    None => {
+                        if self.cascade_defaults && section != self.default_section {
+                            return self.getint(&self.default_section, &key);
+                        }
+                        Ok(None)
+                    },
                 },
-                None => Ok(None),
+                None => {
+                    if self.cascade_defaults && section != self.default_section {
+                        return self.getint(&self.default_section, &key);
+                    }
+                    Ok(None)
+                },
             },
-            None => Ok(None),
+            None => {
+                if self.cascade_defaults && section != self.default_section {
+                    return self.getint(&self.default_section, &key);
+                }
+                Ok(None)
+            },
         }
     }
 
@@ -1105,11 +1198,26 @@ impl Ini {
                         Err(why) => Err(why.to_string()),
                         Ok(uint) => Ok(Some(uint)),
                     },
-                    None => Ok(None),
+                    None => {
+                        if self.cascade_defaults && section != self.default_section {
+                            return self.getuint(&self.default_section, &key);
+                        }
+                        Ok(None)
+                    },
                 },
-                None => Ok(None),
+                None => {
+                    if self.cascade_defaults && section != self.default_section {
+                        return self.getuint(&self.default_section, &key);
+                    }
+                    Ok(None)
+                },
             },
-            None => Ok(None),
+            None => {
+                if self.cascade_defaults && section != self.default_section {
+                    return self.getuint(&self.default_section, &key);
+                }
+                Ok(None)
+            },
         }
     }
 
@@ -1134,11 +1242,26 @@ impl Ini {
                         Err(why) => Err(why.to_string()),
                         Ok(float) => Ok(Some(float)),
                     },
-                    None => Ok(None),
+                    None => {
+                        if self.cascade_defaults && section != self.default_section {
+                            return self.getfloat(&self.default_section, &key);
+                        }
+                        Ok(None)
+                    },
                 },
-                None => Ok(None),
+                None => {
+                    if self.cascade_defaults && section != self.default_section {
+                        return self.getfloat(&self.default_section, &key);
+                    }
+                    Ok(None)
+                },
             },
-            None => Ok(None),
+            None => {
+                if self.cascade_defaults && section != self.default_section {
+                    return self.getfloat(&self.default_section, &key);
+                }
+                Ok(None)
+            },
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -384,6 +384,151 @@ empty_option=
 }
 
 #[test]
+fn test_cascade_defaults() -> Result<(), Box<dyn Error>> {
+    use configparser::ini::IniDefault;
+
+    const FILE_CONTENTS: &str = "
+[DEFAULT]
+fallback_str = fallback value
+fallback_bool = true
+fallback_bool_c = 1
+fallback_int = -42
+fallback_uint = 42
+fallback_float = 3.1415
+
+[fallback_section]
+normal = section value
+other_bool = false
+other_int = -7
+other_uint = 7
+other_float = 1.1
+
+[override_section]
+other_key = some other value
+fallback_str = non-fallback value
+fallback_bool = false
+fallback_bool_c = 0
+fallback_int = -1
+fallback_uint = 1
+fallback_float = -1.1
+";
+
+    let mut parser_options = IniDefault::default();
+    // true tested in inline_comment_symbols_enabled()
+    parser_options.cascade_defaults = true;
+
+    let mut config = Ini::new_from_defaults(parser_options);
+    config.read(FILE_CONTENTS.to_owned())?;
+
+    assert!(config.defaults().cascade_defaults);
+    // test string values and basics
+    assert_eq!(
+        config.get("default", "fallback_str"),
+        Some(String::from("fallback value"))
+    );
+    assert_eq!(
+        config.get("fallback_section", "normal"),
+        Some(String::from("section value"))
+    );
+    assert_eq!(
+        config.get("fallback_section", "fallback_str"),
+        Some(String::from("fallback value"))
+    );
+    assert_eq!(
+        config.get("override_section", "fallback_str"),
+        Some(String::from("non-fallback value"))
+    );
+    assert_eq!(
+        config.get("override_section", "other_key"),
+        Some(String::from("some other value"))
+    );
+
+    // test bool parsing with fallback
+    assert_eq!(
+        config.getbool("default", "fallback_bool"),
+        Ok(Some(true))
+    );
+    assert_eq!(
+        config.getbool("fallback_section", "fallback_bool"),
+        Ok(Some(true))
+    );
+    assert_eq!(
+        config.getbool("fallback_section", "other_bool"),
+        Ok(Some(false))
+    );
+    assert_eq!(
+        config.getbool("override_section", "fallback_bool"),
+        Ok(Some(false))
+    );
+    assert_eq!(
+        config.getboolcoerce("default", "fallback_bool_c"),
+        Ok(Some(true))
+    );
+    assert_eq!(
+        config.getboolcoerce("fallback_section", "fallback_bool_c"),
+        Ok(Some(true))
+    );
+    assert_eq!(
+        config.getboolcoerce("override_section", "fallback_bool_c"),
+        Ok(Some(false))
+    );
+
+    // test the getint and getuint fallbacks
+    assert_eq!(
+        config.getint("default", "fallback_int"),
+        Ok(Some(-42))
+    );
+    assert_eq!(
+        config.getint("fallback_section", "fallback_int"),
+        Ok(Some(-42))
+    );
+    assert_eq!(
+        config.getint("fallback_section", "other_int"),
+        Ok(Some(-7))
+    );
+    assert_eq!(
+        config.getint("override_section", "fallback_int"),
+        Ok(Some(-1))
+    );
+    assert_eq!(
+        config.getuint("default", "fallback_uint"),
+        Ok(Some(42))
+    );
+    assert_eq!(
+        config.getuint("fallback_section", "fallback_uint"),
+        Ok(Some(42))
+    );
+    assert_eq!(
+        config.getuint("fallback_section", "other_uint"),
+        Ok(Some(7))
+    );
+    assert_eq!(
+        config.getuint("override_section", "fallback_uint"),
+        Ok(Some(1))
+    );
+
+    // and finally, test the float fallback
+    assert_eq!(
+        config.getfloat("default", "fallback_float"),
+        Ok(Some(3.1415))
+    );
+    assert_eq!(
+        config.getfloat("fallback_section", "fallback_float"),
+        Ok(Some(3.1415))
+    );
+    assert_eq!(
+        config.getfloat("fallback_section", "other_float"),
+        Ok(Some(1.1))
+    );
+    assert_eq!(
+        config.getfloat("override_section", "fallback_float"),
+        Ok(Some(-1.1))
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "indexmap")]
 fn sort_on_write() -> Result<(), Box<dyn Error>> {
     let mut config = Ini::new_cs();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -507,7 +507,7 @@ fallback_float = -1.1
         Ok(Some(1))
     );
 
-    // and finally, test the float fallback
+    // test the float fallback
     assert_eq!(
         config.getfloat("default", "fallback_float"),
         Ok(Some(3.1415))
@@ -523,6 +523,34 @@ fallback_float = -1.1
     assert_eq!(
         config.getfloat("override_section", "fallback_float"),
         Ok(Some(-1.1))
+    );
+
+    // and finally, one last set of tests with cascade_defaults disabled to 
+    // ensure backwards compatibility
+    config.set_cascade_defaults(false);
+    assert_eq!(
+        config.get("fallback_section", "fallback_str"),
+        None
+    );
+    assert_eq!(
+        config.getbool("fallback_section", "fallback_bool"),
+        Ok(None)
+    );
+    assert_eq!(
+        config.getboolcoerce("fallback_section", "fallback_bool"),
+        Ok(None)
+    );
+    assert_eq!(
+        config.getint("fallback_section", "fallback_int"),
+        Ok(None)
+    );
+    assert_eq!(
+        config.getuint("fallback_section", "fallback_uint"),
+        Ok(None)
+    );
+    assert_eq!(
+        config.getfloat("fallback_section", "fallback_float"),
+        Ok(None)
     );
 
     Ok(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -444,10 +444,7 @@ fallback_float = -1.1
     );
 
     // test bool parsing with fallback
-    assert_eq!(
-        config.getbool("default", "fallback_bool"),
-        Ok(Some(true))
-    );
+    assert_eq!(config.getbool("default", "fallback_bool"), Ok(Some(true)));
     assert_eq!(
         config.getbool("fallback_section", "fallback_bool"),
         Ok(Some(true))
@@ -474,26 +471,17 @@ fallback_float = -1.1
     );
 
     // test the getint and getuint fallbacks
-    assert_eq!(
-        config.getint("default", "fallback_int"),
-        Ok(Some(-42))
-    );
+    assert_eq!(config.getint("default", "fallback_int"), Ok(Some(-42)));
     assert_eq!(
         config.getint("fallback_section", "fallback_int"),
         Ok(Some(-42))
     );
-    assert_eq!(
-        config.getint("fallback_section", "other_int"),
-        Ok(Some(-7))
-    );
+    assert_eq!(config.getint("fallback_section", "other_int"), Ok(Some(-7)));
     assert_eq!(
         config.getint("override_section", "fallback_int"),
         Ok(Some(-1))
     );
-    assert_eq!(
-        config.getuint("default", "fallback_uint"),
-        Ok(Some(42))
-    );
+    assert_eq!(config.getuint("default", "fallback_uint"), Ok(Some(42)));
     assert_eq!(
         config.getuint("fallback_section", "fallback_uint"),
         Ok(Some(42))
@@ -525,13 +513,10 @@ fallback_float = -1.1
         Ok(Some(-1.1))
     );
 
-    // and finally, one last set of tests with cascade_defaults disabled to 
+    // and finally, one last set of tests with cascade_defaults disabled to
     // ensure backwards compatibility
     config.set_cascade_defaults(false);
-    assert_eq!(
-        config.get("fallback_section", "fallback_str"),
-        None
-    );
+    assert_eq!(config.get("fallback_section", "fallback_str"), None);
     assert_eq!(
         config.getbool("fallback_section", "fallback_bool"),
         Ok(None)
@@ -540,10 +525,7 @@ fallback_float = -1.1
         config.getboolcoerce("fallback_section", "fallback_bool"),
         Ok(None)
     );
-    assert_eq!(
-        config.getint("fallback_section", "fallback_int"),
-        Ok(None)
-    );
+    assert_eq!(config.getint("fallback_section", "fallback_int"), Ok(None));
     assert_eq!(
         config.getuint("fallback_section", "fallback_uint"),
         Ok(None)

--- a/tests/test_cascade_defaults.ini
+++ b/tests/test_cascade_defaults.ini
@@ -1,0 +1,5 @@
+[DEFAULT]
+fallback_key = fallback value
+
+[mysection]
+regular_key = no fallback


### PR DESCRIPTION
This adds an option, `cascade_defaults`, that can be set to enable the cascading of values in the `[DEFAULT]` section to other "concrete" sections.  This is NOT enabled by default to preserve backwards compatibility.  When `cascade_defaults` is set to `true`, this will mimic the behavior of the Python configparser library, wherein the default value will be returned for a section/key lookup that doesn't exist.  For example, with this config:
```
[DEFAULT]
fallback_key = fallback value

[mysection]
other_key = other value
```

With `cascade_defaults` set to `true`, a `config.get("mysection", "fallback_key")` call would return `Some("fallback_value")` instead of `None`.

I've added unit tests in the `test.rs` file to cover the new behavior.  I've also attempted to generally follow the same styles used in code/comments.